### PR TITLE
Fix the query params of the get user method of the login route

### DIFF
--- a/auth-formulary/backend/src/presentation/user/controller.ts
+++ b/auth-formulary/backend/src/presentation/user/controller.ts
@@ -13,8 +13,8 @@ export class UserController {
   constructor() {}
 
   public getUser = async (req: Request, res: Response) => {
-    const password = req.body.password as string | undefined;
-    const mail = req.body.mail as string | undefined;
+    const password = req.query.password as string | undefined;
+    const mail = req.query.mail as string | undefined;
 
     if (password && mail) {
       const userRepository = new UserRepositoryImpl(new MongoUserDatasource());


### PR DESCRIPTION
**Description**
This fix provides support for receiving client data using params. For example:

`/api/login?mail=<my-mail>&password=<my-password>`


